### PR TITLE
fix depricated option "pattern"

### DIFF
--- a/Resources/config/routing.xml
+++ b/Resources/config/routing.xml
@@ -4,7 +4,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="lopi_pusher_bundle_auth" pattern="/auth" methods="POST">
+    <route id="lopi_pusher_bundle_auth" path="/auth" methods="POST">
         <default key="_controller">LopiPusherBundle:Auth:auth</default>
     </route>
 


### PR DESCRIPTION
The "pattern" option laupifrpar\pusher-bundle\Lopi\Bundle\PusherBundle/Resources/config/routing.xml" is deprecated since version 2.2 and will be removed in 3.0.
